### PR TITLE
Redo the erb-attribute conversion

### DIFF
--- a/test/erb/lint_test.rb
+++ b/test/erb/lint_test.rb
@@ -42,17 +42,57 @@ describe ERB::Linter do
       converted_html(
         <<~ERB
           <div>
+            <span data-action="foo->#bar" <%= :bar if bar %>></span>
             <span data-foo="<%= :foo %>" <%= :bar if bar %>></span>
             <span <%= :foo if foo %> <%= :bar if bar %>></span>
             <span data-foo="<%= "foo" %>" <%= "bar" if bar %>></span>
+            <input <%= :foo if foo %> <%= :bar if bar %>/>
+
+              <span
+            data-foo="<%= "foo" %>"
+                   autocomplete
+
+                  <%= "bar" if bar %>
+           data-foo="bar><!'"
+           ></span>
+           <test
+             data-controller="foo"
+             data-foo-configuration-value='{
+               "bar0": true,
+               "bar1": true,
+               "bar2": false,
+               "bar3": false,
+               "bar4": <%= @bar %>
+             }'
+           >
           </div>
         ERB
       ).must_equal(
         <<~HTML
           <div>
+            <span data-action="foo->#bar" data-erb-0="&lt;%= :bar if bar %&gt;"></span>
             <span data-erb-data-foo="&lt;%= :foo %&gt;" data-erb-0="&lt;%= :bar if bar %&gt;"></span>
             <span data-erb-0="&lt;%= :foo if foo %&gt;" data-erb-1="&lt;%= :bar if bar %&gt;"></span>
             <span data-erb-data-foo="&lt;%= &quot;foo&quot; %&gt;" data-erb-0="&lt;%= &quot;bar&quot; if bar %&gt;"></span>
+            <input data-erb-0="&lt;%= :foo if foo %&gt;" data-erb-1="&lt;%= :bar if bar %&gt;"/>
+
+              <span
+            data-erb-data-foo="&lt;%= &quot;foo&quot; %&gt;"
+                   autocomplete
+
+                  data-erb-0="&lt;%= &quot;bar&quot; if bar %&gt;"
+           data-foo="bar><!'"
+           ></span>
+           <test
+             data-controller="foo"
+             data-erb-data-foo-configuration-value='{
+               &quot;bar0&quot;: true,
+               &quot;bar1&quot;: true,
+               &quot;bar2&quot;: false,
+               &quot;bar3&quot;: false,
+               &quot;bar4&quot;: &lt;%= @bar %&gt;
+             }'
+           >
           </div>
         HTML
       )


### PR DESCRIPTION
The new approach follows this sequence:
- encode all ERB tags to make them easy to parse
- catch all the encoded ERB tags inside attributes
- decode and escape the ERB tags inside attributes
- decode the remaining encoded ERB tags
- convert the remaining the ERB tags as before

This makes the conversion process resistant to <> inside attribute values, erb-tags in weird places in the attributes list, tags with attributes on different lines, attributes with multiline values.

Fixes #3 