### PR TITLE
Allow string interpolation in attribute names

### DIFF
--- a/lib/erb/linter/converter.rb
+++ b/lib/erb/linter/converter.rb
@@ -48,14 +48,13 @@ module ERB::Linter::Converter
       attributes.map! do |attribute|
         if attribute.match?(erb_tags_matcher)
           space, attribute = attribute.scan(/\A(\s+)(.*)\z/m).flatten
-          attribute.gsub!(erb_tags_matcher, erb_tags)
 
           attribute =
-            case attribute
-            when /\A#{ERB_TAG}\z/
-              %{data-erb-#{i += 1}="#{CGI.escapeHTML(attribute)}"}
-            when /\A#{ATTR_NAME}=/
-              name, value = attribute.split("=", 2)
+            case
+            when /\A#{ERB_TAG}\z/ === attribute.gsub(erb_tags_matcher, erb_tags)
+              %{data-erb-#{i += 1}="#{CGI.escapeHTML(attribute.gsub(erb_tags_matcher, erb_tags))}"}
+            when /\A#{ATTR_NAME}=/ === attribute
+              name, value = attribute.split("=", 2).map { _1.gsub(erb_tags_matcher, erb_tags) }
               quote = '"'
               if value.match(/\A['"]/)
                 quote = value[0]
@@ -63,7 +62,7 @@ module ERB::Linter::Converter
               end
               %{data-erb-#{name}=#{quote}#{CGI.escapeHTML(value)}#{quote}}
             else
-              raise "Don't know how to process attribute: #{attribute.inspect}"
+              raise "Don't know how to process attribute: #{attribute.gsub(erb_tags_matcher, erb_tags).inspect}"
             end
 
           "#{space}#{attribute}"

--- a/test/erb/lint_test.rb
+++ b/test/erb/lint_test.rb
@@ -44,6 +44,7 @@ describe ERB::Linter do
           <div>
             <span data-action="foo->#bar" <%= :bar if bar %>></span>
             <span data-foo="<%= :foo %>" <%= :bar if bar %>></span>
+            <span data-<% identifier %>="bar" data-<% identifier %>-foo="<%= 'bar' %>"></span>
             <span <%= :foo if foo %> <%= :bar if bar %>></span>
             <span data-foo="<%= "foo" %>" <%= "bar" if bar %>></span>
             <input <%= :foo if foo %> <%= :bar if bar %>/>
@@ -72,6 +73,7 @@ describe ERB::Linter do
           <div>
             <span data-action="foo->#bar" data-erb-0="&lt;%= :bar if bar %&gt;"></span>
             <span data-erb-data-foo="&lt;%= :foo %&gt;" data-erb-0="&lt;%= :bar if bar %&gt;"></span>
+            <span data-erb-data-<erb silent erb-code=\" identifier \"></erb>=\"bar\" data-erb-data-<erb silent erb-code=\" identifier \"></erb>-foo=\"&lt;%= &#39;bar&#39; %&gt;\"></span>
             <span data-erb-0="&lt;%= :foo if foo %&gt;" data-erb-1="&lt;%= :bar if bar %&gt;"></span>
             <span data-erb-data-foo="&lt;%= &quot;foo&quot; %&gt;" data-erb-0="&lt;%= &quot;bar&quot; if bar %&gt;"></span>
             <input data-erb-0="&lt;%= :foo if foo %&gt;" data-erb-1="&lt;%= :bar if bar %&gt;"/>


### PR DESCRIPTION
Resolves #5 

This is a partial solution, and I'm hoping to find some guidance to complete it.

I ran into a similar issue to #5 with the following error:

```
Don't know how to process attribute: "data----view-component-identifier----<%=UI::Inputs::NewAddressSelector::Component.identifier %>-outlet=\"<%= UI::Inputs::NewAddressSelector::Component.selector %>\""
```

With my level of understanding of regexp it seems like adjusting the `ATTR_NAME` regexp to allow for erb tags is not possible, as it means removing the characters `<%=> ` from the negated set, however, this would allow full html tags to be included in the match.  For example it would then match `<span foo="bar"` out of `<span foo="bar"></span>` (while we only want `foo="bar"`).

The approach I found to work is the one outlined in this PR.  The solution itself comes down to deferring the substitution of the erb tags such that we don't have to deal with them while matching with the `ATTR_NAME` regexp.  I'm not very happy with this solution because it now requires many lines to call `gsub`, so I hope to improve it before merging. 

Additionally the attribute names produced by this are not valid as they look like this:
```
data-erb-data-<erb silent erb-code=\" identifier \"></erb>=\"bar\"
```